### PR TITLE
Leaflet dependency 0.6.4 -> 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "url": "https://github.com/kartena/Leaflet.Pancontrol/issues"
   },
   "dependencies": {
-    "leaflet": "~0.6.4"
+    "leaflet": "~0.7.1"
   }
 }


### PR DESCRIPTION
Please consider this version change, otherwise it causes terrible conflicts with `browserify`