### PR TITLE
Update cdn to examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="style.css" />
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.css" />
     <!--[if lte IE 8]>
       <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
     <![endif]-->
@@ -16,10 +16,10 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.js"></script>
     <script src="../src/L.Control.Pan.js" ></script>    
     <script src="lib/leaflet-tilejson.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="style.css" />
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.css" />
     <!--[if lte IE 8]>
-      <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
+      <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.ie.css" />
     <![endif]-->
 
     <link rel="stylesheet" href="../src/L.Control.Pan.css" />


### PR DESCRIPTION
LeafletJS [instructs](http://leafletjs.com/download.html#using-a-hosted-version-of-leaflet) to use CloudFlare CDN directly.

Fixes #14