### PR TITLE
remove L.Map.mergeOptions

### DIFF
--- a/src/L.Control.Pan.js
+++ b/src/L.Control.Pan.js
@@ -76,10 +76,6 @@
 		}
 	});
 
-	L.Map.mergeOptions({
-		panControl: false
-	});
-
 	L.Map.addInitHook(function () {
 		if (this.options.panControl) {
 			this.panControl = new L.Control.Pan();


### PR DESCRIPTION
`mergeOptions` made sense when it merged `panControl` with `true` value (until 685bdd9d914481902e1c34ecc2c348a56436387f).
Now it does nothing, as defaults of L.Map does not contain `panControl` property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kartena/leaflet.pancontrol/19)
<!-- Reviewable:end -->
